### PR TITLE
Handle long or infinite scenarios

### DIFF
--- a/examples/advanced.exs
+++ b/examples/advanced.exs
@@ -1,4 +1,6 @@
 defmodule AdvancedScenario do
+  @moduledoc false
+
   @behaviour Beamchmark.Scenario
 
   @out_dir __MODULE__ |> Atom.to_string() |> String.trim_leading("Elixir.")

--- a/examples/simple.exs
+++ b/examples/simple.exs
@@ -1,10 +1,13 @@
 defmodule SimpleScenario do
+  @moduledoc false
+
   @behaviour Beamchmark.Scenario
 
   @impl true
   def run() do
-    Enum.map(1..1_000_000, fn i -> Integer.pow(i, 2) end)
-    :ok
+    1..1_000
+    |> Stream.cycle()
+    |> Stream.each(fn i -> Integer.pow(i, 2) end)
   end
 end
 

--- a/lib/beamchmark/scenario.ex
+++ b/lib/beamchmark/scenario.ex
@@ -1,6 +1,11 @@
 defmodule Beamchmark.Scenario do
   @moduledoc """
   Scenario to run during benchmarking. Defines a behaviour that needs to be adopted by benchmarked modules.
+
+  `Beamchmark` will call the implementation of `run/0` in a new process, shutting it down once it completes all
+  measurements. The implementation should run for a longer period of time (possibly infinite) than measurements,
+  so that the EVM isn't benchmarked while it's idle. For the same reason, it is recommended to `raise` immediately
+  in case the implementation fails.
   """
 
   @typedoc """

--- a/lib/beamchmark/scenario.ex
+++ b/lib/beamchmark/scenario.ex
@@ -11,5 +11,5 @@ defmodule Beamchmark.Scenario do
   @doc """
   The function that will be called during benchmarking.
   """
-  @callback run() :: :ok | {:error, any()}
+  @callback run() :: any()
 end

--- a/lib/beamchmark/suite.ex
+++ b/lib/beamchmark/suite.ex
@@ -63,7 +63,7 @@ defmodule Beamchmark.Suite do
       # the scenario has finished before (config.delay + config.duration) seconds
       {:ok, _result} ->
         Mix.shell().error("""
-        The scenario had been complete before the measurements ended.
+        The scenario had been completed before the measurements ended.
         Consider decreasing duration/delay or making the scenario run longer to get more accurate results.
         """)
 

--- a/test/support/mock_scenario.ex
+++ b/test/support/mock_scenario.ex
@@ -4,5 +4,5 @@ defmodule MockScenario do
   @behaviour Beamchmark.Scenario
 
   @impl true
-  def run(), do: :ok
+  def run(), do: :noop
 end


### PR DESCRIPTION
After these changes, the scenario will be stopped after `delay + duration` seconds (previously, we would wait until its `run/0` function returns). If the scenario was complete before that time, we will warn users that they should either make the scenario run longer or decrease delay/duration.
Also, the API for `Scenario.run/0` behaviour changed (return type was changed from `:ok | {:error, any()}` to just `any()`) – we aren't interested in the return value anymore, the scenario should raise on error.