### PR TITLE
Make restrictions on comparing suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ mix run examples/<example_name>.exs
 ```
 
 ## Formatters
-Currently, Beamchmark supports two ways of printing its reports:
+You can output benchmark results with Beamchmark's built-in formatters or implement a custom one.
+Formatters can also compare new results with the previous ones, given they share the same scenario module and 
+were configured to run for the same amount of time.
+
+Currently, you can output Beamchmark reports in the following ways:
 * `Beamchmark.Formatters.Console`
 
   This is the default formatter, it will print the report on standard output.

--- a/lib/beamchmark.ex
+++ b/lib/beamchmark.ex
@@ -47,7 +47,7 @@ defmodule Beamchmark do
   * `duration` - time in seconds `#{inspect(__MODULE__)}` will be benchmarking EVM. Defaults to `#{@default_duration}` seconds.
   * `delay` - time in seconds `#{inspect(__MODULE__)}` will wait after running scenario and before starting benchmarking. Defaults to `#{@default_delay}` seconds.
   * `formatters` - list of formatters that will be applied to the result. By default contains only `#{inspect(@default_formatter)}`.
-  * `compare?` - boolean indicating whether `#{inspect(__MODULE__)}` should pass previous results to formatters. Defaults to `#{inspect(@default_compare)}.`
+  * `compare?` - boolean indicating whether formatters should compare results for given scenario with the previous one. Defaults to `#{inspect(@default_compare)}.`
   * `output_dir` - directory where results of benchmarking will be saved. Defaults to "`beamchmark`" directory under location provided by `System.tmp_dir!/0`.
   """
   @type options_t() :: [
@@ -62,6 +62,7 @@ defmodule Beamchmark do
   Runs scenario and benchmarks EVM performance.
 
   If `compare?` option equals `true`, invocation of this function will also compare new measurements with the last ones.
+  Measurements will be compared only if they share the same scenario module, delay and duration.
   """
   @spec run(Beamchmark.Scenario.t(), options_t()) :: :ok
   def run(scenario, opts \\ []) do

--- a/lib/beamchmark/suite.ex
+++ b/lib/beamchmark/suite.ex
@@ -1,7 +1,11 @@
 defmodule Beamchmark.Suite do
   @moduledoc """
-  The module defines a struct representing a single run of benchmark.
-  It is responsible for benchmarking and saving/loading the results.
+  The module defines a struct representing a single run of benchmark. It is also responsible for running the
+  benchmark and saving/loading the results.
+
+  The results are serialized and stored in `output_dir / scenario name / delay_duration` directory, where
+  `scenario name` is the name of module implementing scenario (without separating dots) and `output_dir`,
+  `delay`, `duration` are fetched from the suite's configuration.
   """
 
   alias Beamchmark.Scenario
@@ -89,7 +93,7 @@ defmodule Beamchmark.Suite do
 
     File.write!(new_path, :erlang.term_to_binary(suite))
 
-    Mix.shell().info("Results successfully saved to #{inspect(config.output_dir)} directory.")
+    Mix.shell().info("The results were saved to \"#{inspect(config.output_dir)}`\" directory.")
   end
 
   @spec try_load_base(t()) :: {:ok, t()} | {:error, File.posix()}


### PR DESCRIPTION
closes #7 
This PR prevents comparing suites with different scenarios or different delay/duration.

Results now will be saved to `config.output_dir / scenario name / delay_duration` directory.