### PR TITLE
Support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tool for measuring EVM performance.
 
 At the moment, the main interest of Beamchmark is scheduler utilization, reductions and the number of context switches.
 For more information please refer to API docs.
+Currently, Beamchmark is supported on macOS, Linux and partially on Windows.
 
 ## Beamchmark and Benchee
 Beamchmark should be used when you want to measure BEAM performance while it is running your application.
@@ -212,7 +213,7 @@ Currently, you can output Beamchmark reports in the following ways:
 
 * Custom formatters
 
-  You can implement your custom formatters by overriding `Beamchmark.Formatter` behaviour.
+  You can implement your custom formatters by overriding `Beamchmark.`Formatter` behavior.
 
 ## Copyright and License
 Copyright 2021, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=beamchmark)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Currently, you can output Beamchmark reports in the following ways:
 
 * Custom formatters
 
-  You can implement your custom formatters by overriding `Beamchmark.Formatter` behavior.
+  You can implement your custom formatters by overriding `Beamchmark.Formatter` behaviour.
 
 ## Copyright and License
 Copyright 2021, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=beamchmark)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Currently, you can output Beamchmark reports in the following ways:
 
 * Custom formatters
 
-  You can implement your custom formatters by overriding `Beamchmark.`Formatter` behavior.
+  You can implement your custom formatters by overriding `Beamchmark.Formatter` behavior.
 
 ## Copyright and License
 Copyright 2021, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=beamchmark)

--- a/examples/simple.exs
+++ b/examples/simple.exs
@@ -11,4 +11,5 @@ defmodule SimpleScenario do
   end
 end
 
-Beamchmark.run(SimpleScenario, duration: 5, delay: 1)
+# Beamchmark.run(SimpleScenario, duration: 5, delay: 1)
+Beamchmark.run(SimpleScenario, duration: 5, delay: 1, formatters: [Beamchmark.Formatters.HTML])

--- a/examples/simple.exs
+++ b/examples/simple.exs
@@ -11,5 +11,4 @@ defmodule SimpleScenario do
   end
 end
 
-# Beamchmark.run(SimpleScenario, duration: 5, delay: 1)
-Beamchmark.run(SimpleScenario, duration: 5, delay: 1, formatters: [Beamchmark.Formatters.HTML])
+Beamchmark.run(SimpleScenario, duration: 5, delay: 1)

--- a/lib/beamchmark/formatters/html.ex
+++ b/lib/beamchmark/formatters/html.ex
@@ -40,7 +40,9 @@ defmodule Beamchmark.Formatters.HTML do
 
   @impl true
   def write(content, options) do
-    output_path = options |> Keyword.get(:output_path, @default_output_path) |> Path.expand()
+    output_path =
+      options |> Keyword.get(:output_path, @default_output_path) |> Path.expand() |> format_path()
+
     auto_open? = Keyword.get(options, :auto_open?, @default_auto_open)
 
     dirname = Path.dirname(output_path)
@@ -73,6 +75,13 @@ defmodule Beamchmark.Formatters.HTML do
       {:unix, :darwin} -> "open"
       {:unix, _} -> "xdg-open"
       {:win32, _} -> "explorer"
+    end
+  end
+
+  def format_path(path) do
+    case :os.type() do
+      {:win32, _} -> String.replace(path, "/", "\\")
+      _ -> path
     end
   end
 end

--- a/lib/beamchmark/formatters/html.ex
+++ b/lib/beamchmark/formatters/html.ex
@@ -82,7 +82,7 @@ defmodule Beamchmark.Formatters.HTML do
   defp format_path(path) do
     case Utils.os() do
       :Windows -> String.replace(path, "/", "\\")
-      _ -> path
+      _os -> path
     end
   end
 end

--- a/lib/beamchmark/formatters/html.ex
+++ b/lib/beamchmark/formatters/html.ex
@@ -5,6 +5,7 @@ defmodule Beamchmark.Formatters.HTML do
 
   @behaviour Beamchmark.Formatter
 
+  alias Beamchmark.Utils
   alias Beamchmark.Suite
   alias __MODULE__.Templates
 
@@ -71,16 +72,16 @@ defmodule Beamchmark.Formatters.HTML do
   end
 
   defp get_browser() do
-    case :os.type() do
-      {:unix, :darwin} -> "open"
-      {:unix, _} -> "xdg-open"
-      {:win32, _} -> "explorer"
+    case Utils.os() do
+      :macOS -> "open"
+      :Windows -> "explorer"
+      :Linux -> "xdg-open"
     end
   end
 
-  def format_path(path) do
-    case :os.type() do
-      {:win32, _} -> String.replace(path, "/", "\\")
+  defp format_path(path) do
+    case Utils.os() do
+      :Windows -> String.replace(path, "/", "\\")
       _ -> path
     end
   end

--- a/lib/beamchmark/formatters/html.ex
+++ b/lib/beamchmark/formatters/html.ex
@@ -72,15 +72,16 @@ defmodule Beamchmark.Formatters.HTML do
   end
 
   defp get_browser() do
-    case Utils.os() do
+    case Utils.get_os_name() do
       :macOS -> "open"
       :Windows -> "explorer"
       :Linux -> "xdg-open"
+      os_name -> raise RuntimeError, message: "Beamchmark not supported for #{os_name}"
     end
   end
 
   defp format_path(path) do
-    case Utils.os() do
+    case Utils.get_os_name() do
       :Windows -> String.replace(path, "/", "\\")
       _os -> path
     end

--- a/lib/beamchmark/suite/cpu/cpu_task.ex
+++ b/lib/beamchmark/suite/cpu/cpu_task.ex
@@ -56,12 +56,13 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
 
   @spec cpu_snapshot() :: CpuInfo.cpu_snapshot_t()
   defp cpu_snapshot() do
-    to_cpu_snapshot(:cpu_sup.util([:per_cpu]))
+    IO.inspect(:cpu_sup.util([:per_cpu]))
+    |> to_cpu_snapshot()
   end
 
   # Converts output of `:cpu_sup.util([:per_cpu])` to `cpu_snapshot_t`
   @spec to_cpu_snapshot(any()) :: CpuInfo.cpu_snapshot_t()
-  defp to_cpu_snapshot(cpu_util_result) do
+  defp to_cpu_snapshot(cpu_util_result) when is_list(cpu_util_result) do
     cpu_core_usage_map =
       Enum.reduce(cpu_util_result, %{}, fn {core_id, usage, _idle, _mix}, cpu_core_usage_acc ->
         Map.put(cpu_core_usage_acc, core_id, usage)
@@ -75,6 +76,13 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
     %{
       cpu_usage: cpu_core_usage_map,
       average_all_cores: average_all_cores
+    }
+  end
+
+  defp to_cpu_snapshot({:all, avg_usage, _non_busy, _misc}) do
+    %{
+      cpu_usage: %{all: avg_usage / 1},
+      average_all_cores: avg_usage / 1
     }
   end
 end

--- a/lib/beamchmark/suite/cpu/cpu_task.ex
+++ b/lib/beamchmark/suite/cpu/cpu_task.ex
@@ -24,15 +24,32 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
   @spec start_link(cpu_interval :: pos_integer(), duration :: pos_integer()) :: Task.t()
   def start_link(cpu_interval, duration) do
     Task.async(fn ->
-      run_poll(
-        cpu_interval,
-        duration
-      )
+      run_poll(cpu_interval, duration)
     end)
   end
 
   @spec run_poll(number(), number()) :: {:ok, CpuInfo.t()}
   defp run_poll(cpu_interval, duration) do
+    do_run_poll(Utils.get_os_name(), cpu_interval, duration)
+  end
+
+  @spec do_run_poll(atom(), number(), number()) :: {:ok, CpuInfo.t()}
+  defp do_run_poll(:Windows, cpu_interval, duration) do
+    iterations_number = trunc(duration / cpu_interval)
+    pid = self()
+
+    Task.async(fn ->
+      Enum.each(0..(iterations_number - 1), fn _it_num ->
+        spawn(__MODULE__, :cpu_snapshot, [:Windows, pid])
+        Process.sleep(cpu_interval)
+      end)
+    end)
+
+    cpu_snapshots = receive_snapshots(iterations_number)
+    {:ok, CpuInfo.from_cpu_snapshots(cpu_snapshots)}
+  end
+
+  defp do_run_poll(_os, cpu_interval, duration) do
     iterations_number = trunc(duration / cpu_interval)
     :cpu_sup.start()
     # First run returns garbage acc to docs
@@ -55,27 +72,51 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
     {:ok, CpuInfo.from_cpu_snapshots(cpu_snapshots)}
   end
 
-  @spec cpu_snapshot() :: CpuInfo.cpu_snapshot_t()
-  defp cpu_snapshot() do
-    cpu_snapshot(Utils.get_os_name())
+  defp receive_snapshots(snapshots_no, cpu_snapshots \\ []) do
+    case snapshots_no do
+      0 ->
+        cpu_snapshots
+
+      _snapshots_no ->
+        cpu_snapshots =
+          receive do
+            {:cpu_snapshot, snapshot} ->
+              IO.puts("received snapshot")
+              [snapshot | cpu_snapshots]
+          end
+
+        receive_snapshots(snapshots_no - 1, cpu_snapshots)
+    end
   end
 
-  defp cpu_snapshot(:Windows) do
+  @spec cpu_snapshot(:Windows, pid()) :: nil
+  def(cpu_snapshot(:Windows, pid)) do
     {cpu_util_result, 0} = System.cmd("wmic", ["cpu", "get", "loadpercentage"])
 
     average_all_cores =
-      cpu_util_result
-      |> String.split("\r\r\n")
-      |> Enum.at(1)
-      |> String.trim()
-      |> Integer.parse()
-      |> elem(0)
-      |> Kernel./(1)
+      try do
+        cpu_util_result
+        |> String.split("\r\r\n")
+        |> Enum.at(1)
+        |> String.trim()
+        |> Float.parse()
+        |> elem(0)
+      rescue
+        ArgumentError -> 0.0
+      end
 
-    %{cpu_usage: %{}, average_all_cores: average_all_cores}
+    send(
+      pid,
+      {:cpu_snapshot,
+       %{
+         cpu_usage: %{},
+         average_all_cores: average_all_cores
+       }}
+    )
   end
 
-  defp cpu_snapshot(_os) do
+  @spec cpu_snapshot() :: CpuInfo.cpu_snapshot_t()
+  defp cpu_snapshot() do
     cpu_util_result = :cpu_sup.util([:per_cpu])
 
     cpu_core_usage_map =

--- a/lib/beamchmark/suite/cpu/cpu_task.ex
+++ b/lib/beamchmark/suite/cpu/cpu_task.ex
@@ -56,8 +56,7 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
 
   @spec cpu_snapshot() :: CpuInfo.cpu_snapshot_t()
   defp cpu_snapshot() do
-    IO.inspect(:cpu_sup.util([:per_cpu]))
-    |> to_cpu_snapshot()
+    :cpu_sup.util([:per_cpu]) |> to_cpu_snapshot()
   end
 
   # Converts output of `:cpu_sup.util([:per_cpu])` to `cpu_snapshot_t`

--- a/lib/beamchmark/suite/cpu/cpu_task.ex
+++ b/lib/beamchmark/suite/cpu/cpu_task.ex
@@ -57,7 +57,7 @@ defmodule Beamchmark.Suite.CPU.CpuTask do
 
   @spec cpu_snapshot() :: CpuInfo.cpu_snapshot_t()
   defp cpu_snapshot() do
-    cpu_snapshot(Utils.os())
+    cpu_snapshot(Utils.get_os_name())
   end
 
   defp cpu_snapshot(:Windows) do

--- a/lib/beamchmark/suite/system_info.ex
+++ b/lib/beamchmark/suite/system_info.ex
@@ -23,7 +23,7 @@ defmodule Beamchmark.Suite.SystemInfo do
       elixir_version: System.version(),
       otp_version: :erlang.system_info(:otp_release) |> List.to_string(),
       nif_version: :erlang.system_info(:nif_version) |> List.to_string(),
-      os: Utils.os(),
+      os: Utils.get_os_name(),
       arch: :erlang.system_info(:system_architecture) |> List.to_string(),
       num_cores: System.schedulers_online()
     }

--- a/lib/beamchmark/suite/system_info.ex
+++ b/lib/beamchmark/suite/system_info.ex
@@ -3,6 +3,8 @@ defmodule Beamchmark.Suite.SystemInfo do
   The module defines a struct containing various information about system that is used for benchmarking.
   """
 
+  alias Beamchmark.Utils
+
   @type t :: %__MODULE__{
           elixir_version: String.t(),
           otp_version: String.t(),
@@ -21,20 +23,9 @@ defmodule Beamchmark.Suite.SystemInfo do
       elixir_version: System.version(),
       otp_version: :erlang.system_info(:otp_release) |> List.to_string(),
       nif_version: :erlang.system_info(:nif_version) |> List.to_string(),
-      os: os(),
+      os: Utils.os(),
       arch: :erlang.system_info(:system_architecture) |> List.to_string(),
       num_cores: System.schedulers_online()
     }
-  end
-
-  defp os() do
-    {_family, name} = :os.type()
-
-    case name do
-      :darwin -> :macOS
-      :nt -> :Windows
-      :freebsd -> :FreeBSD
-      _other -> :Linux
-    end
   end
 end

--- a/lib/beamchmark/utils.ex
+++ b/lib/beamchmark/utils.ex
@@ -3,6 +3,7 @@ defmodule Beamchmark.Utils do
   The module defines utility functions for Beamchmark.
   """
 
+  @spec os :: :FreeBSD | :Linux | :Windows | :macOS
   def os() do
     {_family, name} = :os.type()
 

--- a/lib/beamchmark/utils.ex
+++ b/lib/beamchmark/utils.ex
@@ -1,0 +1,16 @@
+defmodule Beamchmark.Utils do
+  @moduledoc """
+  The module defines utility functions for Beamchmark.
+  """
+
+  def os() do
+    {_family, name} = :os.type()
+
+    case name do
+      :darwin -> :macOS
+      :nt -> :Windows
+      :freebsd -> :FreeBSD
+      _other -> :Linux
+    end
+  end
+end

--- a/lib/beamchmark/utils.ex
+++ b/lib/beamchmark/utils.ex
@@ -3,8 +3,8 @@ defmodule Beamchmark.Utils do
   The module defines utility functions for Beamchmark.
   """
 
-  @spec os :: :FreeBSD | :Linux | :Windows | :macOS
-  def os() do
+  @spec get_os_name :: :FreeBSD | :Linux | :Windows | :macOS
+  def get_os_name() do
     {_family, name} = :os.type()
 
     case name do


### PR DESCRIPTION
Fixed Beamchmark crashing on Windows.
Fixed Beamchmark not opening HTML report due to wrong path format.
Added average CPU utilization measurement for Windows.