### PR TITLE
Fixed html_test failing for Windows.

### DIFF
--- a/test/beamchmark/formatters/html_test.exs
+++ b/test/beamchmark/formatters/html_test.exs
@@ -49,7 +49,7 @@ defmodule Beamchmark.Formatters.HTMLTest do
       html_assets_linked = HTML.format(suite, inline_assets?: false)
       html_assets_inlined = HTML.format(suite, inline_assets?: true)
 
-      expected_size_linked = 20_000
+      expected_size_linked = 16_000
       expected_size_inlined = 3_670_000
 
       assert_in_delta byte_size(html_assets_linked),
@@ -65,7 +65,7 @@ defmodule Beamchmark.Formatters.HTMLTest do
       html_assets_linked = HTML.format(suite, suite, inline_assets?: false)
       html_assets_inlined = HTML.format(suite, suite, inline_assets?: true)
 
-      expected_size_linked = 20_000
+      expected_size_linked = 16_000
       expected_size_inlined = 3_670_000
 
       assert_in_delta byte_size(html_assets_linked),


### PR DESCRIPTION
Due to fewer metrics gathered on Windows the report size shrunk under the anticipated size.