### PR TITLE
Remove Windows test dependency from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     uses: membraneframework/membrane_actions/.github/workflows/test.yml@main
 
   hex_publish:
-    needs: [build_test, lint, test, windows_test]
+    needs: [build_test, lint, test]
     uses: membraneframework/membrane_actions/.github/workflows/hex-publish.yml@main
     secrets:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
Windows test dependency was removed from CI workflow but not from Release.